### PR TITLE
Fix use directory urls without `.html` extension

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -6,6 +6,11 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 
 ## [Unreleased]
 
+## [0.3.0]
+
+### Fixed
+- Metro site `use_directory_urls` default config became ineffective issue 1053
+
 ## [0.2.3] - 2025-09-16
 
 ### Discovered

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -5,7 +5,11 @@ theme:
 
 plugins:
   - search
+  # Versioned Metro docs site for each release
+  # https://github.com/jimporter/mike
   - mike
+  # https://github.com/sondregronas/mkdocs-callouts
+  - callouts
 
 extra:
   version:

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-click==8.2.2
+click==8.2.1
 future==1.0.0
 Jinja2==3.1.6
 livereload==2.7.1
@@ -6,7 +6,7 @@ lunr==0.8.0
 Markdown==3.9
 MarkupSafe==3.0.2
 mkdocs==1.6.1
-mkdocs-material==9.6.16
+mkdocs-material==9.6.20
 mike==2.1.3
 mkdocs-get-deps==0.2.0
 mkdocs-macros-plugin==1.3.9


### PR DESCRIPTION
This pull request introduces updates to the documentation configuration and changelog to support versioned documentation and improve site features. The most important changes are grouped below.

Documentation configuration enhancements:

* Added the `mike` plugin to `mkdocs.yml` to enable versioned documentation for each release.
* Added the `callouts` plugin to `mkdocs.yml` for enhanced documentation formatting.

Changelog updates:

* Added a new `0.3.0` section to `docs/CHANGELOG.md` and documented the fix for the Metro site `use_directory_urls` default config issue.